### PR TITLE
bug(#34) Read result from error observable for async and subscribe within service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -174,11 +174,9 @@ export class AppComponent implements OnInit {
      */
     const { timeout, ...config } = this.getConfig(); // Omit timeout
     this.snotifireService
-      .async('This will resolve with error', 'Async', errorAction, config)
-      .subscribe();
+      .async('This will resolve with error', 'Async', errorAction, config);
     this.snotifireService
-      .async('This will resolve with success', successAction, config)
-      .subscribe();
+      .async('This will resolve with success', successAction, config);
     this.snotifireService
       .async(
         'Called with promise',
@@ -198,8 +196,7 @@ export class AppComponent implements OnInit {
           setTimeout(() => resolve({}), 1500);
         }),
         config
-      )
-      .subscribe();
+      );
   }
 
   onConfirmation() {


### PR DESCRIPTION
The current implementation of async toasts is broken, even the sample webpage expects the error object to update the toast config.

This change will now correctly read the config from any error thrown, and also subscribe within the async function rather than leaving it for the caller to subscribe to the observable themselves.